### PR TITLE
Add 'configure' hook

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapctl restart $SNAP_NAME.discoveryserver

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,9 @@ hooks:
   install:
     plugs:
       - network
+  configure:
+    plugs:
+      - network
 
 parts:
   etcd:


### PR DESCRIPTION
The configure hook restarts the discoveryserver daemon, without this stage is not possible to override listen.address config.

    $ sudo snap set discoveryserver listen.server=10.5.1.75
    error: cannot perform the following tasks:
    - Run configure hook of "discoveryserver" snap (snap "discoveryserver" has no "configure" hook)